### PR TITLE
Fixed  for  supporting  Linestring, MultiLinestring, MultiPolyGon

### DIFF
--- a/src/geojson.js
+++ b/src/geojson.js
@@ -5,8 +5,16 @@ module.exports.polygon = justType('Polygon', 'POLYGON');
 function justType(type, TYPE) {
     return function(gj) {
         var oftype = gj.features.filter(isType(type));
+        var geometries;
+        if (TYPE === 'POLYGON') {
+            geometries = [oftype.map(justCoords)];
+        } else if (TYPE === 'POLYLINE') {
+            geometries = oftype.map(function(t) { return [justCoords(t)]; });
+        } else {
+            geometries = oftype.map(justCoords);
+        }
         return {
-            geometries: (TYPE === 'POLYGON' || TYPE === 'POLYLINE') ? [oftype.map(justCoords)] : oftype.map(justCoords),
+            geometries: geometries,
             properties: oftype.map(justProps),
             type: TYPE
         };

--- a/src/geojson.js
+++ b/src/geojson.js
@@ -36,5 +36,5 @@ function justProps(t) {
 }
 
 function isType(t) {
-    return function(f) { return f.geometry.type === t; };
+    return function(f) { return f.geometry.type.replace('Multi', '') === t; };
 }


### PR DESCRIPTION

Now we are able to download shape file for    Linestring, MultiLinestring and MultiPolyGon.

(1) Fix for Linestring shapefile issue for reference  https://github.com/mapbox/shp-write/issues/44#issuecomment-310360267 

(2) Fix for  MultiLinestring and MultiPolyGon issue for reference https://github.com/mapbox/shp-write/pull/65/commits/82bbc9f636c444644ecbcaf4cfe8153ca6a7d40e 



    